### PR TITLE
Fix name for 'show all' hash key (broken in 36e0166)

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -7882,7 +7882,7 @@ sub config {
         }
         for my $s (sort keys %$config) {
             next if ! $all and ! grep { $s =~ /$_/i } @nouns;
-            printf "%-*s = %s\n", $maxsize, $s, $config->{$s}{value};
+            printf "%-*s = %s\n", $maxsize, $s, $config->{$s}{setting};
         }
         exit 1;
     }


### PR DESCRIPTION
When value was renamed from `value` to `setting`, it seems this key lookup was missed. This diff updates the key to match the db table.
