### PR TITLE
use $sth->rows() to get number of rows.

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -7716,11 +7716,10 @@ sub table_has_rows {
     ## Some types do not have a count
     return 0 if $x->{does_append_only};
  
-    my $rv;
     if ($x->{does_limit}) {
         $SQL = "SELECT 1 FROM $tname LIMIT 1";
         $sth = $x->{dbh}->prepare($SQL);
-        $rv = $sth->execute();
+        $sth->execute();
         $count = $sth->rows();
         $sth->finish();
         return $count >= 1 ? 1 : 0;
@@ -7733,7 +7732,7 @@ sub table_has_rows {
     elsif ('oracle' eq $x->{dbtype}) {
         $SQL = "SELECT 1 FROM $tname WHERE rownum > 1";
         $sth = $x->{dbh}->prepare($SQL);
-        $rv = $sth->execute();
+        $sth->execute();
         $count = $sth->rows();
         $sth->finish();
         return $count >= 1 ? 1 : 0;


### PR DESCRIPTION
From the DBI manpage:

'A DBI statement handle execute always returns true regardless of the number of rows affected, even it's zero." It only returns the number of rows affected for non-"SELECT" statements.'

This patch ensures that we get the proper count by calling $sth->rows() instead of relying on $sth->execute.
