### PR TITLE
Status extras

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -9419,8 +9419,8 @@ exist, it will be created. Optional.
 
 =item C<makedelta>
 
-Turns makedelta magic on or off. Value is a list of databases which need makedelta
-for this table. Value can also be "on" to enable makedelta for all databases.
+Turns makedelta magic on or off. Value is a list of databases which need makedelta 
+for this table. Value can also be "on" to enable makedelta for all databases. 
 Defaults to "off".
 
 =back


### PR DESCRIPTION
Added two new metrics to status_detail - data rate and replication lag.

Data Rate is the number of insert / delete / truncate and conflict operations, from syncstats, in the last 5 minutes (as operations per second)

Replication Lag is calculated in two ways:
- the age of the oldest outstanding delta, if there are any outstanding deltas in any of the source databases
- the total_time of the last good syncrun, if there are no outstanding deltas.

e.g.
# ./bucardo status testsync

Last good                : May 21, 2013 11:44:43 (time to run: 1s)
Rows deleted/inserted    : 0 / 6
Sync name                : testsync
Current state            : Good
...
Data rate (per second)   : insert: 0.10, delete: 0, truncate: 0, conflict: 0
Lag seconds/deltas       : 0.45 / 0
# ...
