### PR TITLE
fixed bucardo start when PIDDIR does not exists

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -781,6 +781,9 @@ sub start {
     ## This will automatically write any nouns in as well
     append_reason_file('start');
 
+   print "Create if needed pid directory: - $PIDDIR  - ";
+    my $ouputls = `mkdir -p  $PIDDIR`;
+
     ## Refuse to go on if we get a ping response within 5 seconds
     $QUIET or print "Checking for existing processes\n";
 


### PR DESCRIPTION
We should have to re create the folder before running bucardo start

this change would fix it
