### PR TITLE
array_agg was introduced in postgresql 8.4 not 8.3

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -7201,10 +7201,10 @@ sub validate_sync {
     my $oidlist = join ',' => map { $_->{oid} } @{ $s->{goatlist} };
     if ($oidlist) {
 
-        ## Postgres added the array_agg function in 8.3, so if this is older than that,
+        ## Postgres added the array_agg function in 8.4, so if this is older than that,
         ## we add our own copy
         my $arrayagg = 'array_agg';
-        if ($srcdbh->{pg_server_version} < 80300) {
+        if ($srcdbh->{pg_server_version} < 80400) {
 
             ## We reset the search_path below, so we need to force the query below to use the public namespace
             $arrayagg = 'public.array_agg';


### PR DESCRIPTION
At the moment bucardo is not working correctly replicating postgresql 8.3. Problem is that it relies on array_agg which was introduced in postgresql 8.4, although there is a correct fallback function, the detection of version was not correct.

The problem was already reported here: https://github.com/bucardo/bucardo/issues/44
