### PR TITLE
Create PIDDIR directory if missing

### DIFF
--- a/dist/bucardo.init
+++ b/dist/bucardo.init
@@ -43,6 +43,10 @@ bucardo_flags="--quiet ${hostopt} ${portopt} --db-name ${DBNAME} --db-user ${DBU
 RETVAL=0
 
 start() {
+     # Make sure that PIDDIR directory exists before starting
+     if [ ! -d "${PIDDIR}" ]; then
+         mkdir -p "${PIDDIR}"
+     fi
      # Make sure that bucardo is not already running:
      if [ -f "${PIDDIR}/bucardo.mc.pid" ]; then
          echo -n "${NAME} is already running"


### PR DESCRIPTION
Since the directory configuration is set in /etc/default/bucardo (and its default value is present in this script), I think it makes sense to contain the responsibility to create the directory to the bucardo.init script rather than modifying bucardo perl script.

This addresses bucardo#99
