### PR TITLE
map timestamp from PostgreSQL to MongoDB datetime

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -13,6 +13,8 @@ package Bucardo;
 use 5.008003;
 use strict;
 use warnings;
+use Date::Parse;
+use DateTime;
 use utf8;
 use open qw( :std :utf8 );
 
@@ -9866,6 +9868,9 @@ sub push_rows {
                             }
                             elsif ($Table->{columnhash}{$key}{ftype} =~ /real|double|numeric/o) {
                                 $object->{$key} = strtod($object->{$key});
+                            }
+                            elsif ($Table->{columnhash}{$key}{ftype} =~ /timestamp with time zone|date|abstime/o) {
+                                $object->{$key} = DateTime->from_epoch(epoch => str2time($object->{$key}));
                             }
                         }
                         $self->{collection}->insert($object, { safe => 1 });


### PR DESCRIPTION
In the 'mongomagic' section of Bucardo.pm I and Aric Fedida wanted to map "timestamp" objects from PostgreSQL to actual MongoDB datetime objects.
