### PR TITLE
Add auth and select to Redis on_connect

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -5693,15 +5693,29 @@ sub connect_database {
         elsif ('redis' eq $dbtype) {
             my @dsn;
             my $server = '';
-            if (defined $d->{host} and length $d->{host}) {
-                $server = $d->{host};
+            if (defined $d->{dbhost} and length $d->{dbhost}) {
+                $server = $d->{dbhost};
             }
-            if (defined $d->{port} and length $d->{port}) {
-                $server = ":$d->{port}";
+            if (defined $d->{dbport} and length $d->{dbport}) {
+                $server = ":$d->{dbport}";
             }
             if ($server) {
                 push @dsn => 'server', $server;
             }
+
+            my ($pass, $index);
+            if (defined $d->{dbpass} and length $d->{dbpass}) {
+                $pass = $d->{dbpass};
+            }
+            if (defined $d->{dbname} and length $d->{dbname} and $d->{dbname} !~ /\D/) {
+                $index = $d->{dbname};
+            }
+
+            push @dsn => 'on_connect', sub {
+                $_[0]->client_setname('bucardo');
+                $_[0]->auth($pass) if $pass;
+                $_[0]->select($index) if $index;
+            };
 
             ## For now, we simply require it
             require Redis;

--- a/bucardo
+++ b/bucardo
@@ -1944,6 +1944,20 @@ sub add_database {
                     push @dsn => 'server', $server;
                 }
 
+                my ($pass, $index);
+                if (exists $tempdsn->{pass}) {
+                    $pass = $tempdsn->{pass};
+                }
+                if (exists $tempdsn->{name} and $tempdsn->{name} !~ /\D/) {
+                    $index = $tempdsn->{name};
+                }
+
+                push @dsn => 'on_connect', sub {
+                    $_[0]->client_setname('bucardo');
+                    $_[0]->auth($pass) if $pass;
+                    $_[0]->select($index) if $index;
+                };
+
                 $evalok = 0;
                 eval {
                     $testdbh = Redis->new(@dsn);
@@ -2478,17 +2492,11 @@ sub list_databases {
                 $showhost ? qq{\@$showhost} : '';
         }
         if ($dbtype eq 'redis') {
-            my $server = '';
-            if (length $info->{dbhost}) {
-                $server .= $info->{dbhost};
-            }
-            if (length $info->{dbport}) {
-                $server .= ":$info->{dbport}";
-            }
-            if ($server) {
-                $server = "server=$server";
-                print "Conn: $server";
-            }
+            my $showindex = (length $info->{dbname} and $info->{dbname} !~ /\D/) ? " -n $info->{dbname}" : '';
+            printf 'Conn: redis-cli %s%s%s',
+                $showhost,
+                $showport,
+                $showindex;
         }
         if ($dbtype eq 'sqlite') {
             printf 'Conn: sqlite3 %s',

--- a/bucardo.schema
+++ b/bucardo.schema
@@ -829,7 +829,7 @@ if ($dbtype eq 'oracle') {
 
 if ($dbtype eq 'redis') {
    my $connstring = "$dbtype\n";
-   for my $name (qw/ host port user pass /) {
+   for my $name (qw/ host port user pass name /) {
      defined $db{$name} and length $db{$name} and $connstring .= "$name: $db{$name}\n";
    }
    chomp $connstring;


### PR DESCRIPTION
Support Redis in protected mode (requirepass/masterauth), and use the dbname from bucardo.db to select the Redis database (typically 0-15) if it's an integer. Also, fix some obvious (?) bugs in `connect_database`, and clean up `list_databases` to match what's done for the other dbtypes.
