### PR TITLE
Fix up postgres version checking regexp

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -9026,7 +9026,8 @@ sub install {
         }
     }
 
-    if ($res !~ /(\d+)\.(\d+)(\S+)/) {
+    ## Find a version -- the first number in the line after delimiter (5 or more of symbols '-')
+    if ($res !~ /-{5,}\n[^d]*(\d+)\.(\d+)(\S+)/) {
         print "-->Sorry, unable to connect to the database\n\n";
         warn $delayed_warning;
         exit 1 if $bcargs->{batch};


### PR DESCRIPTION
If current working directory not allowed to access, then psql crashes
with error "could not change directory to DIR", and if this DIR contains
numbers, e.g. "DBIx-Safe-1.2.5", then version of postgres will be filled
with this numbers, and command "bucardo install" will be crashed.
The solution of this problem is extending of regexp that used for
finding postgres version.