### PR TITLE
Add --foreground option

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -233,6 +233,7 @@ sub new {
         logseparate  => 0,
         logextension => '',
         logclean     => 0,
+        foreground   => 0,
         dryrun       => 0,
         sendmail     => 1,
         extraname    => '',
@@ -470,13 +471,15 @@ sub start_mcp {
     };
     $disconnect_ok or $self->glog("Warning! Disconnect failed $@", LOG_WARN);
 
-    my $seeya = fork;
-    if (! defined $seeya) {
-        die q{Could not fork mcp!};
-    }
-    ## Immediately close the child process (one side of the fork)
-    if ($seeya) {
-        exit 0;
+    unless ($self->{foreground}) {
+        my $seeya = fork;
+        if (! defined $seeya) {
+            die q{Could not fork mcp!};
+        }
+        ## Immediately close the child process (one side of the fork)
+        if ($seeya) {
+            exit 0;
+        }
     }
 
     ## Now that we've forked, overwrite the PID file with our new value

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
 Bucardo version ???
 
+  - Add foreground flag
+    [Chris Barbour]
+
   - Fix bug in onetimecopy=2 mode
     [Greg Sabino Mullane]
 

--- a/bucardo
+++ b/bucardo
@@ -89,6 +89,7 @@ my $bcargs = {
               logextension => '',
               logclean     => 0,
               batch        => 0,
+              foreground   => 0,
           };
 
 ## These options must come before the main GetOptions call
@@ -157,6 +158,7 @@ GetOptions ## no critic (ProhibitCallsToUndeclaredSubs)
      'retry=i',
      'retrysleep|retry-sleep=i',
      'batch',
+     'foreground',
      'dryrun|dry-run',
      'confirm',
      'tsep=s',
@@ -866,14 +868,19 @@ sub start {
     my %remove = map { $_ => undef } @nouns;
     @opts = grep { ! exists $remove{$_} } @opts;
 
-    ## Fork and setsid to disassociate ourselves from the daemon
-    if (fork) {
-        ## We are the kid, do nothing
-    }
-    else {
-        setsid() or die;
-        ## Here we go!
-        $bc->start_mcp( \@opts );
+    ## Check if we should daemonize
+    if ($bcargs->{'foreground'}) {
+	$bc->start_mcp( \@opts );
+    } else {
+        ## Fork and setsid to disassociate ourselves from the daemon
+        if (fork) {
+            ## We are the kid, do nothing
+        }
+        else {
+            setsid() or die;
+            ## Here we go!
+            $bc->start_mcp( \@opts );
+        }
     }
 
     exit 0;
@@ -10320,6 +10327,11 @@ F<log.bucardo>. A dot is added before the name as well, so a log extension of
 =item C<--log-clean>
 
 Forces removal of all old log files before running.
+
+=item C<--foreground>
+
+Run bucardo in the foreground; do not daemonize. Useful for running bucardo
+inside a container or from systemd.
 
 =item C<--debug>
 


### PR DESCRIPTION
This PR adds a `--foreground` flag to the start command.

The ability to run Bucardo in the foreground is very useful if you want to manage bucardo with supervisord, systemd (as a service unit), or monit. It's practically required to run Bucardo in a container. Most of these tools react to daemonization as if the program has terminated.

The implementation is very simple; tasks relating to forking and detaching from the parent process are wrapped in conditional logic. This helps to minimize changes to the code-path. While it might be possible to make some of the prep logic for daemonization conditional, doing so would increase the likelihood of introducing bugs.

Full disclosure: It's been a long time since I've written anything in Perl. I did basic testing, but would advise a cautious review before accepting.