### PR TITLE
Updates regex for un-named columns

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -2152,7 +2152,7 @@ sub start_controller {
             $saved_sourcedbh->rollback();
 
             ## Make sure none of them are un-named, which Postgres outputs as ?column?
-            if (grep { /\?/ } @{ $g->{tcolumns}{$SELECT} }) {
+            if (grep { /^\?.*\?$/ } @{ $g->{tcolumns}{$SELECT} }) {
                 die "Invalid customcols given: must give an alias to all columns! ($g->{tcolumns}{$SELECT}) for $SELECT\n";
             }
 


### PR DESCRIPTION
- the regex currently matches on any existence of `?` in a column_name which
is valid to have in an actual Postgres column name (even if not conventional)
- updates the regex to match only on columns that begin and end with a `?`
character (i.e. `?column?`)