### PR TITLE
Avoid race condition in reload_config

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -954,8 +954,8 @@ sub reload {
 
     ## We want to wait to hear from the MCP that it is done
     my $done = 'bucardo_reloaded_mcp';
-    $dbh->do('NOTIFY bucardo_mcp_reload');
     $dbh->do("LISTEN $done");
+    $dbh->do('NOTIFY bucardo_mcp_reload');
     $dbh->commit();
 
     ## Wait a little bit, then scan for the confirmation message
@@ -1005,8 +1005,8 @@ sub reload_config {
 
     ## We want to wait to hear from the MCP that it is done
     my $done = 'bucardo_reload_config_finished';
-    $dbh->do('NOTIFY bucardo_reload_config');
     $dbh->do("LISTEN $done");
+    $dbh->do('NOTIFY bucardo_reload_config');
     $dbh->commit();
 
     ## Wait a little bit, then scan for the confirmation message


### PR DESCRIPTION
First LISTEN for bucardo_reload_config_finished, and NOTIFY
bucardo_reload_config only after that. This ordering matches the
bucardo_mcp_pong handling in the same function.