### PR TITLE
Improve the unique conflict exception handler sample code and test

### DIFF
--- a/t/40-customcode-exception.t
+++ b/t/40-customcode-exception.t
@@ -58,7 +58,8 @@ $SQL = q{
   CREATE TABLE employee (
     id SERIAL PRIMARY KEY,
     fullname TEXT,
-    email TEXT UNIQUE
+    email TEXT UNIQUE,
+    updated_at timestamptz DEFAULT clock_timestamp()
 );
 };
 $dbhA->do($SQL); $dbhB->do($SQL); $dbhC->do($SQL);
@@ -113,8 +114,8 @@ for my $db (qw/ A B C /) {
 }
 
 ## Cause a unique index violation and confirm the sync dies
-$insert_eb->execute(102, 'Mallory1', 'mallory@acme' );
 $insert_ec->execute(103, 'Mallory2', 'mallory@acme' );
+$insert_eb->execute(102, 'Mallory1', 'mallory@acme' );
 
 $dbhA->commit(); $dbhB->commit(); $dbhC->commit();
 

--- a/t/40-customcode-exception.t
+++ b/t/40-customcode-exception.t
@@ -169,7 +169,7 @@ $t = q{Sync exabc shows a duplicate key violation};
 like ($res, qr{ERROR.*sub_email_key}, $t);
 
 ## Add in a customcode exception handler
-$res = $bct->ctl('bucardo add customcode email_exception whenrun=exception src_code=t/customcode.exception.bucardotest.pl sync=exabc getdbh=1');
+$res = $bct->ctl('bucardo add customcode email_exception whenrun=exception src_code=t/customcode.exception.bucardotest.pl relation=public.employee getdbh=1');
 
 $t = q{Customcode exception handler was added for sync exabc};
 like ($res, qr{Added customcode "email_exception"}, $t);

--- a/t/40-customcode-exception.t
+++ b/t/40-customcode-exception.t
@@ -32,6 +32,9 @@ $dbhA = $bct->repopulate_cluster('A');
 $dbhB = $bct->repopulate_cluster('B');
 $dbhC = $bct->repopulate_cluster('C');
 
+plan (skip_all =>  'Conflict resolution script requires Postgres 9.4 or later')
+    if $dbhA->{pg_server_version} < 90400;
+
 ## Store into hashes for convenience
 
 my %dbh = (A=>$dbhA, B=>$dbhB, C=>$dbhC);

--- a/t/40-customcode-exception.t
+++ b/t/40-customcode-exception.t
@@ -118,6 +118,7 @@ for my $db (qw/ A B C /) {
 ## Cause a unique index violation and confirm the sync dies
 $insert_ec->execute(103, 10, 'Mallory2', 'mallory@acme' );
 $insert_eb->execute(102, 10, 'Mallory1', 'mallory@acme' );
+$insert_ea->execute(104, 11, 'Mallory1', 'mallory@acme' );
 
 $dbhA->commit(); $dbhB->commit(); $dbhC->commit();
 
@@ -162,7 +163,8 @@ for my $db (qw/ A B C /) {
     is_deeply ($result,[
                [100,10,'alice@acme','Alice'],
                [101,10,'bob@acme','Bob'],
-               [102,10,'mallory@acme','Mallory1']
+               [102,10,'mallory@acme','Mallory1'],
+               [104,11,'mallory@acme','Mallory1'],
        ],$t);
 }
 

--- a/t/40-customcode-exception.t
+++ b/t/40-customcode-exception.t
@@ -11,9 +11,13 @@ use lib 't','.';
 use DBD::Pg;
 use Test::More;
 
+
 use vars qw/ $dbhX $dbhA $dbhB $dbhC $res $command $t $SQL %pkey %sth %sql $sth $count $val /;
 
 use BucardoTesting;
+
+plan (skip_all =>  'Conflict resolution script requires Postgres 9.4 or later')
+if BucardoTesting::pg_major_version() < 9.4;
 my $bct = BucardoTesting->new({location => 'postgres'})
     or BAIL_OUT "Creation of BucardoTesting object failed\n";
 
@@ -31,9 +35,6 @@ END {
 $dbhA = $bct->repopulate_cluster('A');
 $dbhB = $bct->repopulate_cluster('B');
 $dbhC = $bct->repopulate_cluster('C');
-
-plan (skip_all =>  'Conflict resolution script requires Postgres 9.4 or later')
-    if $dbhA->{pg_server_version} < 90400;
 
 ## Store into hashes for convenience
 

--- a/t/BucardoTesting.pm
+++ b/t/BucardoTesting.pm
@@ -238,6 +238,7 @@ else {
     die qq{Could not determine initdb version information from running "$initdb -V"\n};
 }
 
+sub pg_major_version { join '.', $pg_major_version, $pg_minor_version }
 
 ## Each database can also have a custom version
 ## We do this by setting PGBINDIR[A-Z]

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -64,7 +64,7 @@ my %pks = map { $_ => 1 } map { keys %{ $_ } } values %{ $info->{deltabin} };
 
 # Very unlikely to happen, but check anyway.
 unless (%pks) {
-    $info->{warning} = 'No database records found!';
+    $info->{warning} = "Conflict detected on $schema.$table($columns) but no records found!";
     return;
 }
 

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -2,7 +2,11 @@
 
 ## Sample exception handler
 ## For this example, we will resolve unique violations by keeping the most
-## recent record with the conflicting value.
+## recent record with the conflicting value and deleting the other values
+## and any records that references them. It uses a general purpose design,
+## requiring only a single-column primary key and a single column
+## timestamp so as to keep the record with the latest time. Feel free to
+## adapt to your use cases.
 
 use strict;
 use warnings;
@@ -24,7 +28,7 @@ my $time_col = 'updated_at';
 # deleted, list them here and the script will delete them, first. List in
 # the order to be deleted. Format as arryays: [$schema, $table, $fk_column].
 my @cascade  = (
-    # qw(log employee id)],
+    [qw(public supplies employee_id)],
 );
 
 ##############################################################################

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -7,10 +7,23 @@
 ## requiring only a single-column primary key and a single column
 ## timestamp so as to keep the record with the latest time. Feel free to
 ## adapt to your use cases.
+##
+## To add this script to a sync, assuming the setting of the variables in the
+## next section, run this command, replacing `{sync}` with the name of the
+## sync it applies to.
+##
+##     bucardo add customcode employee_subid_email_conflict \
+##            whenrun=exception \
+##            src_code=bucardo_unique_conflict_resolution.pl \
+##            sync={sync} \
+##            getdbh=1 \
+##            relation=public.employee
 
 use strict;
 use warnings;
 
+##############################################################################
+# Configuration
 ##############################################################################
 # Set these variables to specify the unique constraint conflict to resolve.
 # Quote identifiers properly for inclusion in queries. The value of $columns
@@ -34,7 +47,8 @@ my @cascade  = (
 # Optionaly set $copy_to to table with idencial columns to $table to store away
 # deleted records for later evaluation or recovery.
 my $copy_to  = 'employee_conflict';
-
+##############################################################################
+# End of Configuration
 ##############################################################################
 
 my $info = shift;

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -16,7 +16,7 @@ use warnings;
 my $schema   = 'public';
 my $table    = 'employee';
 my $pk_col   = 'id';
-my $columns  = 'email';
+my $columns  = 'subid, email';
 my $time_col = 'updated_at';
 
 # If there are any tables with FK constraints pointint to records to be

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -49,7 +49,8 @@ unless (%pks) {
     return;
 }
 
-# Query each database for the PKs, hashed unique key, and update time.
+# Query each database for the PKs, unique expression value as a JSON array,
+# that same array hashed, and update time.
 my $query = qq{
     SELECT $pk_col                               AS pkey,
            json_build_array($columns)            AS val,

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -1,15 +1,18 @@
 #! perl
 
 ## Sample exception handler
-## For this example, we will fix unique violations on an email column
-
-#! perl
+## For this example, we will resolve unique violations by keeping the most
+## recent record with the conflicting value.
 
 use strict;
 use warnings;
 
 ##############################################################################
-# Set these variables to speciy the unique constraint conflict to resolve.
+# Set these variables to speciy the unique constraint conflict to resolve. Quote
+# properly for inclusion in queries, including ident quoting where appropriate.
+# The value of $columns should be a the exact query expression used to create
+# the unique constraint, generally a comma-delimited list of one or more
+# columns, but may also use a function, such as `LOWER(email)`.
 my $schema   = 'public';
 my $table    = 'employee';
 my $pk_col   = 'id';
@@ -26,13 +29,11 @@ my @cascade  = (
 ##############################################################################
 
 my $info = shift;
-
 return if $info->{schemaname} ne $schema || $info->{tablename} ne $table;
 
 # Do nothing unless it a unique constraint violation for the columns.
 return if $info->{error_string} !~ /violates unique constraint/
-       || $info->{error_string} !~ /DETAIL:\s+Key \($columns\)/;
-
+       || $info->{error_string} !~ /DETAIL:\s+Key\s+\Q($columns)\E/;
 
 # Grab all the primary keys involved in the sync
 my %pks = map { $_ => 1 } map { keys %{ $_ } } values %{ $info->{deltabin} };

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -3,77 +3,103 @@
 ## Sample exception handler
 ## For this example, we will fix unique violations on an email column
 
+#! perl
+
 use strict;
 use warnings;
-use Data::Dumper;
+
+##############################################################################
+# Set these variables to speciy the unique constraint conflict to resolve.
+my $schema   = 'public';
+my $table    = 'employee';
+my $pk_col   = 'id';
+my $columns  = 'email';
+my $time_col = 'updated_at';
+
+# If there are any tables with FK constraints pointint to records to be
+# deleted, list them here and the script will delete them, first. List in
+# the order to be deleted. Format as arryays: [$schema, $table, $fk_column].
+my @cascade  = (
+    # qw(log employee id)],
+);
+
+##############################################################################
 
 my $info = shift;
 
-## Do nothing unless this is the exact error we were designed to handle
-return if $info->{error_string} !~ /violates unique constraint "employee_email_key"/o;
+return if $info->{schemaname} ne $schema || $info->{tablename} ne $table;
 
-## Grab all the primary keys involved in the sync
-my %pk;
-for my $dbname ( keys %{ $info->{deltabin} }) {
-    for my $pkey (keys %{ $info->{deltabin}{$dbname} }) {
-        $pk{$pkey}++;
-    }
-}
+# Do nothing unless it a unique constraint violation for the columns.
+return if $info->{error_string} !~ /violates unique constraint/
+       || $info->{error_string} !~ /DETAIL:\s+Key \($columns\)/;
 
-## Very unlikely to happen, but we will check anyway:
-if (! keys %pk) {
+
+# Grab all the primary keys involved in the sync
+my %pks = map { $_ => 1 } map { keys %{ $_ } } values %{ $info->{deltabin} };
+
+# Very unlikely to happen, but we will check anyway:
+unless (%pks) {
     $info->{warning} = 'No database records found!';
     return;
 }
 
-## We need to get information from every database on each involved record
-my $SQL = sprintf 'SELECT id,email FROM employee WHERE id IN (%s)',
-    (join ',' => sort keys %pk);
+# Query each database for the PKs, hashed unique key, and update time.
+my $query = qq{
+    SELECT $pk_col                               AS pkey,
+           json_build_array($columns)            AS val,
+           md5(json_build_array($columns)::TEXT) AS ukey,
+           extract(epoch FROM $time_col)         AS utime,
+           ?::TEXT                               AS db
+      FROM $schema.$table
+     WHERE $pk_col = ANY(?)
+};
 
-## Emails must be unique, so each must be associated with only one primary key (id)
-my %emailpk;
+# We'll want one instance of each unique key.
+my %rec_for;
 
-## This is in the preferred order of databases
-## Thus, any "conflicts" means A > B > C
-for my $db (qw/ A B C /) {
-    my $dbh = $info->{dbh}{$db};
-    my $sth = $dbh->prepare($SQL);
-    $sth->execute();
-    my $rows = $sth->fetchall_arrayref();
-    for my $row (@$rows) {
-        my ($id,$email) = @$row;
+# Always work the databases in the same order.
+my $dbhs = $info->{dbh};
+for my $db (sort keys %{ $dbhs }) {
+    my $dbh = $dbhs->{$db};
+    my $sth = $dbh->prepare($query);
+    $sth->execute($db, [keys %pks]);
 
-        ## This a new email? All is good, just move on
-        if (! exists $emailpk{$email}) {
-            $emailpk{$email} = [$id, $db];
+    while (my $curr_rec = $sth->fetchrow_hashref) {
+        # This a new unique key? All is good, just move on
+        my $prev_rec = $rec_for{ $curr_rec->{ukey} } || do {
+            $rec_for{ $curr_rec->{ukey} } = $curr_rec;
             next;
-        }
+        };
 
-        ## This email already exists. If the same PK, no problem
-        my ($oldid,$olddb) = @{ $emailpk{$email} };
-        if ($oldid == $id) {
-            next;
-        }
+        # This unique key already exists. If the same PK, no problem
+        next if $curr_rec->{pkey} eq $prev_rec->{pkey};
 
-        ## We have the same email with different PKs! Time to get busy
-        $info->{message} .= "Found problem with email $email. ";
-        $info->{message} .= "Exists as PK $oldid on db $olddb, but as PK $id on $db!";
+        # Keep the record with the latest update time.
+        my ($keep, $lose) = $curr_rec->{utime} > $prev_rec->{utime}
+            ? ($curr_rec, $prev_rec)
+            : ($prev_rec, $curr_rec);
+        $rec_for{ $keep->{ukey} } = $keep;
 
-        ## Store it away in a separate table
-        my $SQL = 'INSERT INTO employee_conflict SELECT * FROM employee WHERE id = ?';
-        $sth = $dbh->prepare($SQL);
-        $sth->execute($id);
+        # Store away the older record in a separate table
+        $dbhs->{ $lose->{db} }->do(
+            'INSERT INTO employee_conflict SELECT * FROM employee WHERE id = ?',
+            $lose->{pkey},
+        );
 
-        ## Now delete it from this database!
-        $SQL = 'DELETE FROM employee WHERE id = ?';
-        $sth = $dbh->prepare($SQL);
-        $sth->execute($id);
+        # Cascade delete the older record.
+        $dbhs->{ $lose->{db} }->do(
+            "DELETE FROM $_->[0].$_->[1] WHERE $_->[2] = ?",
+            $lose->{pkey},
+        ) for @cascade, [$schema, $table, $pk_col];
 
-        ## Note: we do not want to commit (and it is disallowed by DBIx::Safe)
+        # Log the resolution.
+        $info->{message} .= qq{Unique conflict on $schema.$table($columns) for value \`$keep->{val}\` resolved by deleting $pk_col \`$lose->{pkey}\` from database $lose->{db} and keeping $pk_col \`$keep->{pkey}\` from database $keep->{db}};
+
+        # Note: we do not want to commit (and it is disallowed by DBIx::Safe)
     }
 }
 
-## Let's retry now that things are cleaned up!
+# Retry now that things are cleaned up!
 $info->{retry} = 1;
 
 return;

--- a/t/customcode.exception.bucardotest.pl
+++ b/t/customcode.exception.bucardotest.pl
@@ -8,15 +8,16 @@ use strict;
 use warnings;
 
 ##############################################################################
-# Set these variables to speciy the unique constraint conflict to resolve. Quote
-# properly for inclusion in queries, including ident quoting where appropriate.
-# The value of $columns should be a the exact query expression used to create
-# the unique constraint, generally a comma-delimited list of one or more
-# columns, but may also use a function, such as `LOWER(email)`.
+# Set these variables to specify the unique constraint conflict to resolve.
+# Quote identifiers properly for inclusion in queries. The value of $columns
+# should be a the exact query expression used to create the unique constraint
+# or index, generally a comma-delimited list of one or more columns or function
+# calls, function, such as `lower(email)`. Check the constrait expression as
+# shown by Postgres itself to ensure an exact match.
 my $schema   = 'public';
 my $table    = 'employee';
 my $pk_col   = 'id';
-my $columns  = 'subid, email';
+my $columns  = 'subid, lower(email)';
 my $time_col = 'updated_at';
 
 # If there are any tables with FK constraints pointint to records to be


### PR DESCRIPTION
Teach it to handle multiple columns, column expressions (from `CREATE UNIQUE INDEX`), resolution by keeping the latest record, and to cascade deletes to other tables (in case foreign keys are not set to `ON DELETE CASCADE`. The idea is that many folks can take this script as-is, set a few variables, adde it, and go. I tried each of these variants over several commits; it might be useful to add more tests for the variations. 