### PR TITLE
Replace deprecated TG_RELNAME with TG_TABLE_NAME

### DIFF
--- a/t/BucardoTesting.pm
+++ b/t/BucardoTesting.pm
@@ -823,7 +823,7 @@ sub add_test_schema {
                 LANGUAGE plpgsql
                 AS $_$ BEGIN
                 INSERT INTO droptest_bucardo(name,type)
-                    VALUES (TG_RELNAME, 'trigger');
+                    VALUES (TG_TABLE_NAME, 'trigger');
                 RETURN NULL;
                 END;
                 $_$
@@ -837,7 +837,7 @@ sub add_test_schema {
                 LANGUAGE plpgsql
                 AS $_$ BEGIN
                 INSERT INTO droptest_bucardo(name,type)
-                    VALUES (TG_RELNAME, 'trigger');
+                    VALUES (TG_TABLE_NAME, 'trigger');
                 RETURN NULL;
                 END;
                 $_$;


### PR DESCRIPTION
The TG_RELNAME variable which is used in the test schema has been
deprecated since PostgreSQL 8.2 and replaced with TG_TABLE_NAME.

See PostgreSQL commit 3a9ae3d2068334bbd0e54efaa729e7590994ccc8.