### PR TITLE
Exclude schemas starting with "pg_", not just with "pg" prefix 

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -7198,7 +7198,7 @@ sub add_all_goats {
         . qq{WHERE relkind = '$kind' };
 
     ## We always exclude information_schema, system, and bucardo schemas
-    $SQL .= q{AND n.nspname <> 'information_schema' AND nspname !~ '^pg' AND nspname !~ '^bucardo'};
+    $SQL .= q{AND n.nspname <> 'information_schema' AND nspname !~ '^pg_' AND nspname !~ '^bucardo'};
 
     my @clause;
 


### PR DESCRIPTION
During the migration, PostgreSQL system schemas starting with `pg_` should be excluded. 
Currently, all schemas starting with `pg` are filtered out when sync is added. Only schemas starting with `pg_` (with an underscore) should be excluded to avoid filtering out user schemas.

Valid user schemas, which are filtered out without this fix:
```
pg-example
pgexample
```

In our case we had a schema called `pg-boss`.