### PR TITLE
Fix source database selection for add herd

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -4069,9 +4069,10 @@ sub add_herd {
     ## May also insert to the bucardo.herdmap and bucardo.goat tables
     ## Arguments: one or more
     ## 1. Name of the herd
-    ## 2+ Names of tables or sequences to add. Can have wildcards
+    ## 2. Name of the source database
+    ## 3+ Names of tables or sequences to add. Can have wildcards
     ## Returns: undef
-    ## Example: bucardo add herd foobar tab1 tab2
+    ## Example: bucardo add herd foobar source_db tab1 tab2
 
     my $doc_section = 'add/add relgroup';
 
@@ -4089,6 +4090,9 @@ sub add_herd {
         $QUIET or print qq{Created relgroup "$herdname"\n};
     }
 
+    ## Set correct source database for herd
+    my $source_database = shift @nouns;
+
     ## Everything else is tables or sequences to add to this herd
 
     ## How many arguments were we given?
@@ -4101,7 +4105,7 @@ sub add_herd {
     }
 
     ## Get the list of all requested tables, adding as needed
-    my $goatlist = get_goat_ids(args => \@nouns, noherd => $herdname);
+    my $goatlist = get_goat_ids(args => \@nouns, dbcols => { db => $source_database }, noherd => $herdname);
 
     ## The final output. Store it up all at once for a single QUIET check
     my $message = '';
@@ -4146,6 +4150,7 @@ sub add_herd {
         for my $tmpgoat (@a) {
             next if exists $doneit->{$tmpgoat->{id}};
             my $db = $tmpgoat->{db};
+            next if $db ne $source_database;
             my $pri = 0;
 
             $count = $sth->execute($herdname,$pri,$name,$db);


### PR DESCRIPTION
In case a new herd is added to Bucardo via the add herd command, Bucardo doesn't allow the user to specify the desired source database as parameter, although the called function 'get_goat_ids' would allow providing the source database as a parameter already. Instead Bucardo has its own algorithm to determine the 'best' source database in the function 'find_best_db_for_searching'. Unfortunately the algorithm of 'find_best_db_for_searching' just takes the first created source database which will lead to issues if multiple databases are migrated at once.
With this fix Bucardo considers the first parameter after the provided herd name as source database and therefore selects the correct source database for the data migration.
