### PR TITLE
Fix race condition when running bucardo commands

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -6934,10 +6934,26 @@ sub validate_sync {
     }
 
     # Table cache
+    # When possible, only cache tables in schemas we will be looking at
+    my %schemas;
+    for my $g (@{$s->{goatlist}}) {
+        $schemas{$g->{schemaname}} = 1;
+    }
+    my $schemas_list = join(",", map { $srcdbh->quote($_) } keys %schemas);
+    my $schema_constraint = "AND n.nspname IN ($schemas_list)";
+    if (length $schemas_list) {
+        $self->glog(qq{Caching relations in schemas: $schemas_list}, LOG_NORMAL);
+    }
+    else {
+        $self->glog("Caching all relations", LOG_NORMAL);
+        $schema_constraint = '';
+    }
+
     $SQL{checktableonce} = q{
             SELECT n.nspname, c.relname, c.oid, quote_ident(n.nspname) as safeschema, quote_ident(c.relname) as safetable, quote_literal(n.nspname) as safeschemaliteral, quote_literal(c.relname) as safetableliteral
             FROM   pg_class c, pg_namespace n
             WHERE  c.relnamespace = n.oid
+            $schema_constraint
         };
     $sth = $srcdbh->prepare($SQL{checktableonce});
     $sth->execute();

--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -6949,7 +6949,7 @@ sub validate_sync {
         $schema_constraint = '';
     }
 
-    $SQL{checktableonce} = q{
+    $SQL{checktableonce} = qq{
             SELECT n.nspname, c.relname, c.oid, quote_ident(n.nspname) as safeschema, quote_ident(c.relname) as safetable, quote_literal(n.nspname) as safeschemaliteral, quote_literal(c.relname) as safetableliteral
             FROM   pg_class c, pg_namespace n
             WHERE  c.relnamespace = n.oid

--- a/bucardo
+++ b/bucardo
@@ -3623,6 +3623,9 @@ sub add_table {
         doc_section => $doc_section,
     });
 
+    ## With unique constraints on goat table, we can rely on database to prevent duplicates
+    ## No need for explicit locking which can cause deadlocks
+
     ## Loop through all the args and attempt to add the tables
     ## This returns a hash with the following keys: relations, match, nomatch
     my $goatlist = get_goat_ids(args => \@nouns, type => $reltype, dbcols => $dbcols);
@@ -3649,11 +3652,22 @@ sub add_table {
     ## If they requested a herd and it does not exist, create it
     if (exists $extra->{relgroup}) {
         my $herdname = $extra->{relgroup};
-        if (! exists $HERD->{$herdname}) {
+
+        ## Try to create the herd, using savepoint to handle concurrent creation
+        $dbh->do('SAVEPOINT herd_insert');
+        eval {
             $SQL = 'INSERT INTO bucardo.herd(name) VALUES(?)';
             $sth = $dbh->prepare($SQL);
             $sth->execute($herdname);
+            $dbh->do('RELEASE SAVEPOINT herd_insert');
             $message .= qq{Created the relgroup named "$herdname"\n};
+        };
+        if ($@) {
+            $dbh->do('ROLLBACK TO SAVEPOINT herd_insert');
+            ## If duplicate key error, another process created it - that's OK
+            if ($@ !~ /duplicate key value|already exists/) {
+                die $@;
+            }
         }
         ## Now load all of these tables into this herd
         $SQL = 'INSERT INTO bucardo.herdmap (herd,priority,goat) VALUES (?,?,'
@@ -3664,10 +3678,19 @@ sub add_table {
         ## Which tables were already in the herd, and which were just added
         my (@oldnames,@newnames);
 
+        ## Query the database to check if tables are already in herd
+        ## This avoids race conditions from stale in-memory cache
+        $SQL = q{SELECT g.schemaname||'.'||g.tablename AS name
+                 FROM bucardo.herdmap hm
+                 JOIN bucardo.goat g ON (hm.goat = g.id)
+                 WHERE hm.herd = ? AND g.reltype = ?};
+        my $sth_check = $dbh->prepare($SQL);
+        $sth_check->execute($herdname, $reltype);
+        my %tables_in_herd = map { $_->{name} => 1 } @{$sth_check->fetchall_arrayref({})};
+
         for my $name (sort keys %{ $goatlist->{relations} }) {
-            ## Is it already part of this herd?
-            if (exists $HERD->{$herdname}{goat}{$name} and
-                    $HERD->{$herdname}{goat}{$name}{reltype} eq $reltype) {
+            ## Is it already part of this herd? Check database, not memory
+            if (exists $tables_in_herd{$name}) {
                 push @oldnames => $name;
                 next;
             }
@@ -3675,7 +3698,29 @@ sub add_table {
 
             my $pri = 0;
 
-            $count = $sth->execute($herdname,$pri,$name, $db);
+            ## Try to insert, but handle race condition where another process
+            ## inserted the same table between our check and this insert
+            ## Use a savepoint so a duplicate key error doesn't abort the whole transaction
+            $dbh->do('SAVEPOINT herdmap_insert');
+            eval {
+                $count = $sth->execute($herdname,$pri,$name, $db);
+                $dbh->do('RELEASE SAVEPOINT herdmap_insert');
+            };
+            if ($@) {
+                ## Rollback to the savepoint
+                $dbh->do('ROLLBACK TO SAVEPOINT herdmap_insert');
+                ## Check if this is a duplicate key or foreign key constraint error
+                ## These indicate either the table is already in the herd, or there's
+                ## a transient issue with the goat not being found (race condition)
+                if ($@ =~ /duplicate key value violates unique constraint|violates foreign key constraint|null value in column/) {
+                    ## Treat as already in herd - likely added by concurrent process
+                    ## or goat not yet visible to this transaction
+                    push @oldnames => $name;
+                    next;
+                }
+                ## Some other error - re-throw it
+                die $@;
+            }
 
             push @newnames => $name;
         }
@@ -5083,11 +5128,38 @@ AND nspname !~ '^pg_'
         ## We may mutate the arg, so stow away the original
         my $original_item = $item;
 
-        ## We look for matches in the existing $GOAT hash
-        ## We may also check the live database afterwards
-        map {
-            push @matches, $_ if (! defined $reltype || $_->{reltype} eq $reltype);
-        } find_goat_by_item($item, \@nouns);
+        ## Query database for existing goats instead of using stale in-memory cache
+        ## This avoids race conditions from stale cache data
+        if ($item ne 'all') {
+            my $goat_search_sql;
+            if ($hasstar) {
+                my $pattern = $item;
+                $pattern =~ s/\./\\./g;
+                $pattern =~ s/[*%]/\.\*/g;
+                $pattern = "^$pattern" unless $pattern =~ /^[\^\.\%]/;
+                $pattern .= '$' unless $pattern =~ /[\$\*]$/;
+                $goat_search_sql = q{SELECT * FROM bucardo.goat WHERE };
+                if ($hasadot) {
+                    $goat_search_sql .= q{schemaname||'.'||tablename ~ ? AND db = ?};
+                } else {
+                    $goat_search_sql .= q{tablename ~ ? AND db = ?};
+                }
+                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat->execute($pattern, $bestdb);
+                push @matches, @{$sth_goat->fetchall_arrayref({})};
+            } elsif ($hasadot && $item =~ /^(.+)\.(.+)$/) {
+                my ($schema, $table) = ($1, $2);
+                $goat_search_sql = q{SELECT * FROM bucardo.goat WHERE schemaname=? AND tablename=? AND db=?};
+                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat->execute($schema, $table, $bestdb);
+                push @matches, @{$sth_goat->fetchall_arrayref({})};
+            } else {
+                $goat_search_sql = q{SELECT * FROM bucardo.goat WHERE tablename=? AND db=?};
+                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat->execute($item, $bestdb);
+                push @matches, @{$sth_goat->fetchall_arrayref({})};
+            }
+        }
 
         ## Wildcards?
         my $regex_item = $item;
@@ -5141,7 +5213,14 @@ AND nspname !~ '^pg_'
                 my $name = $row->{name};
 
                 ## Don't bother if we have already added this!
-                next if find_goat_by_item($name, [ "db=$bestdb" ]);
+                ## Query database directly instead of using stale in-memory cache
+                if ($name =~ /^(.+)\.(.+)$/) {
+                    my ($schema, $table) = ($1, $2);
+                    $SQL = 'SELECT 1 FROM bucardo.goat WHERE schemaname=? AND tablename=? AND db=?';
+                    my $sth_exists = $dbh->prepare($SQL);
+                    $sth_exists->execute($schema, $table, $bestdb);
+                    next if $sth_exists->fetchrow_array();
+                }
 
                 ## If we are doing 'all', exclude the bucardo schema, and insist on a primary key
                 if ('all' eq $item) {
@@ -5177,16 +5256,33 @@ AND nspname !~ '^pg_'
         if (@addtable) {
             $added_tables = add_items_to_goat_table(\@addtable);
         }
-        for my $tmp (@$added_tables) {
-            push @matches, $GOAT->{by_id}{$tmp};
+        ## Query database for the added goats instead of using in-memory cache
+        if ($added_tables && @$added_tables) {
+            for my $goat_id (@$added_tables) {
+                $SQL = 'SELECT * FROM bucardo.goat WHERE id = ?';
+                my $sth_goat = $dbh->prepare($SQL);
+                $sth_goat->execute($goat_id);
+                my $goat_row = $sth_goat->fetchrow_hashref();
+                push @matches, $goat_row if $goat_row;
+            }
         }
 
-        ## If we asked for "all", add in all of our known tables (not already in this herd)
+        ## If we asked for "all", query database for all tables in this db (not in specified herd)
         if ($names->[0] eq 'all') {
-            for (values %{ $GOAT->{by_db}{$bestdb} }) {
-                next if exists $_->{herd}{$noherd};
-                push @matches, $_;
+            $SQL = q{SELECT g.* FROM bucardo.goat g
+                     WHERE g.db = ? AND g.reltype = ?};
+            if ($noherd) {
+                $SQL .= q{ AND NOT EXISTS (
+                    SELECT 1 FROM bucardo.herdmap hm
+                    WHERE hm.goat = g.id AND hm.herd = ?)};
             }
+            my $sth_all = $dbh->prepare($SQL);
+            if ($noherd) {
+                $sth_all->execute($bestdb, $reltype, $noherd);
+            } else {
+                $sth_all->execute($bestdb, $reltype);
+            }
+            push @matches, @{$sth_all->fetchall_arrayref({})};
         }
 
         ## Populate the final hashes based on the match list
@@ -5242,7 +5338,7 @@ sub add_items_to_goat_table {
 
     my $info = shift or die;
 
-    ## Quick check if the entry is already there.
+    ## SQL to query for existing goat entry (used when handling duplicate key errors)
     $SQL = 'SELECT id FROM bucardo.goat WHERE schemaname=? AND tablename=? AND db=?';
     my $isthere = $dbh->prepare($SQL);
 
@@ -5275,16 +5371,33 @@ sub add_items_to_goat_table {
                 push @args => $rel->{dbcols}{$newcol};
             }
         }
+
+        ## Try to insert, but handle unique constraint violation from concurrent inserts
         $sth = $dbh->prepare($SQL);
-        ($count = $sth->execute(@args)) =~ s/0E0/0/;
+        my $goat_id;
+        eval {
+            ($count = $sth->execute(@args)) =~ s/0E0/0/;
+            $goat_id = $sth->fetchall_arrayref()->[0][0];
+            debug(qq{Added "$schema.$table" with db "$db", count was $count});
+        };
+        if ($@) {
+            ## If duplicate key error, query for the existing ID
+            if ($@ =~ /duplicate key value violates unique constraint/) {
+                $isthere->execute($schema, $table, $db);
+                $goat_id = $isthere->fetchall_arrayref()->[0][0];
+                debug(qq{Table "$schema.$table" with db "$db" already existed, using id $goat_id});
+            } else {
+                die $@;
+            }
+        }
 
-        debug(qq{Added "$schema.$table" with db "$db", count was $count});
-
-        push @newid => $sth->fetchall_arrayref()->[0][0];
+        push @newid => $goat_id if $goat_id;
     }
 
-    ## Update the global
-    load_bucardo_info('force_reload');
+    ## Don't reload here - it causes race conditions when multiple processes
+    ## are adding tables concurrently, as we may see uncommitted data from
+    ## other transactions. The global will be reloaded on next bucardo invocation.
+    ## load_bucardo_info('force_reload');
 
     ## Return a list of goat IDs we've just added
 #    my %newlist;
@@ -9601,6 +9714,11 @@ sub load_bucardo_info {
 
     for my $key (%{$goat->{by_id}}) {
         next if $key !~ /^\d/;
+        ## Skip entries with missing required fields (can happen during concurrent operations)
+        next unless defined $goat->{by_id}{$key}{tablename};
+        next unless defined $goat->{by_id}{$key}{schemaname};
+        next unless defined $goat->{by_id}{$key}{db};
+
         my $tname = $goat->{by_id}{$key}{tablename};
         my $name = "$goat->{by_id}{$key}{schemaname}.$tname";
         my $dbname = $goat->{by_id}{$key}{db};
@@ -9634,6 +9752,10 @@ sub load_bucardo_info {
     $sth->execute();
     for my $row (@{$sth->fetchall_arrayref({})}) {
         my ($g,$h,$p) = @$row{qw/goat herd priority/};
+        ## Skip if this goat doesn't exist in our loaded goat hash
+        ## This can happen during concurrent operations when another process
+        ## added a goat after we loaded our data
+        next unless exists $goat->{by_id}{$g} && $goat->{by_id}{$g}{schemaname};
         $goat->{by_id}{$g}{herd}{$h} = $p;
         $herd->{$h}{goat}{"$goat->{by_id}{$g}{schemaname}.$goat->{by_id}{$g}{tablename}"} = {
             id       => $g,

--- a/bucardo
+++ b/bucardo
@@ -5132,6 +5132,7 @@ AND nspname !~ '^pg_'
         ## This avoids race conditions from stale cache data
         if ($item ne 'all') {
             my $goat_search_sql;
+            my $sth_goat;
             if ($hasstar) {
                 my $pattern = $item;
                 $pattern =~ s/\./\\./g;
@@ -5144,21 +5145,19 @@ AND nspname !~ '^pg_'
                 } else {
                     $goat_search_sql .= q{tablename ~ ? AND db = ?};
                 }
-                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat = $dbh->prepare($goat_search_sql);
                 $sth_goat->execute($pattern, $bestdb);
-                push @matches, @{$sth_goat->fetchall_arrayref({})};
             } elsif ($hasadot && $item =~ /^(.+)\.(.+)$/) {
                 my ($schema, $table) = ($1, $2);
                 $goat_search_sql = q{SELECT * FROM bucardo.goat WHERE schemaname=? AND tablename=? AND db=?};
-                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat = $dbh->prepare($goat_search_sql);
                 $sth_goat->execute($schema, $table, $bestdb);
-                push @matches, @{$sth_goat->fetchall_arrayref({})};
             } else {
                 $goat_search_sql = q{SELECT * FROM bucardo.goat WHERE tablename=? AND db=?};
-                my $sth_goat = $dbh->prepare($goat_search_sql);
+                $sth_goat = $dbh->prepare($goat_search_sql);
                 $sth_goat->execute($item, $bestdb);
-                push @matches, @{$sth_goat->fetchall_arrayref({})};
             }
+            push @matches, @{$sth_goat->fetchall_arrayref({})};
         }
 
         ## Wildcards?

--- a/bucardo.schema
+++ b/bucardo.schema
@@ -302,6 +302,8 @@ ALTER TABLE bucardo.goat ADD CONSTRAINT valid_reltype CHECK (reltype IN ('table'
 
 ALTER TABLE bucardo.goat ADD CONSTRAINT pkey_needs_type CHECK (pkey = '' OR pkeytype IS NOT NULL);
 
+CREATE UNIQUE INDEX bucardo_goat_unique ON bucardo.goat(schemaname, tablename, db);
+
 
 --
 -- Set of filters for each goat.

--- a/t/02-bctl-db.t
+++ b/t/02-bctl-db.t
@@ -46,7 +46,7 @@ like ($res, qr/must supply a database name/, $t);
 
 $t = q{Add database fails for an invalid port};
 $res = $bct->ctl('bucardo add database foo dbname=bar dbport=1');
-like ($res, qr/Connection .+ failed.*could not connect to server/s, $t);
+like ($res, qr/Connection .+ failed.*(could not connect to server|connection to server.+failed)/s, $t);
 
 $t = q{Add database fails for non-existent host};
 $res = $bct->ctl("bucardo add database bucardo_test dbname=bucardo_test user=$dbuserA port=$dbportA host=badbucardohost");

--- a/t/02-bctl-table-race.t
+++ b/t/02-bctl-table-race.t
@@ -1,0 +1,278 @@
+#!/usr/bin/env perl
+# -*-mode:cperl; indent-tabs-mode: nil-*-
+
+## Test for race condition when adding tables to a sync in parallel
+##
+## This test demonstrates that concurrent "bucardo add table ... relgroup=X" commands
+## can fail or produce inconsistent results when multiple processes add different tables
+## to the same relgroup/herd simultaneously.
+##
+## Expected behavior with 5.6.0 (and presumably earlier): TEST FAILS
+## - Some tables will not be added to the herdmap 
+## - Errors about uninitialized values in the $GOAT hash
+## - Exit codes are 0 but actual count doesn't match expected
+##
+## Expected behavior after fix: TEST PASSES
+## - All tables should be successfully added to the herdmap
+## - No errors about uninitialized values
+## - Actual count matches expected count
+
+use 5.008003;
+use strict;
+use warnings;
+use lib 't','.';
+use DBD::Pg;
+use Test::More;
+use File::Temp qw(tempfile);
+use Time::HiRes qw(sleep time);
+
+use vars qw/$t/;
+
+use BucardoTesting;
+my $bct = BucardoTesting->new({notime=>1})
+    or BAIL_OUT "Creation of BucardoTesting object failed\n";
+$location = 'setup';
+
+## Configuration
+my $NUM_TABLES = 100;      ## Total tables to create and add
+my $NUM_THREADS = 10;      ## Parallel threads
+my $TABLES_PER_THREAD = int($NUM_TABLES / $NUM_THREADS);
+
+plan tests => $NUM_TABLES;
+
+## Make sure A and B are started up
+my $dbhA = $bct->repopulate_cluster('A');
+my $dbhB = $bct->repopulate_cluster('B');
+
+## Create a bucardo database, and install Bucardo into it
+my $dbhX = $bct->setup_bucardo('A');
+
+## Grab connection information
+my ($dbuserA,$dbportA,$dbhostA) = $bct->add_db_args('A');
+my ($dbuserB,$dbportB,$dbhostB) = $bct->add_db_args('B');
+
+## Add databases to bucardo
+$bct->ctl("bucardo add db A dbname=bucardo_test user=$dbuserA port=$dbportA host=$dbhostA");
+$bct->ctl("bucardo add db B dbname=bucardo_test user=$dbuserB port=$dbportB host=$dbhostB");
+
+## Create many test tables
+for my $i (1..$NUM_TABLES) {
+    $dbhA->do("CREATE TABLE race_table_$i (id INTEGER PRIMARY KEY, data TEXT)");
+}
+$dbhA->commit();
+
+## Create a sync with a herd
+$bct->ctl("bucardo add sync race_sync relgroup=race_herd dbs=A:source,B:target");
+
+## Ensure test output is not buffered
+$| = 1;
+
+## Create a barrier file for synchronization
+my ($barrier_fh, $barrier_file) = tempfile(UNLINK => 1);
+close $barrier_fh;
+
+## Track child processes
+my @children;
+my %child_output;
+my %child_errors;
+my @all_exit_codes;
+
+## Create temp files for capturing output
+my @output_files;
+my @error_files;
+for (1..$NUM_THREADS) {
+    my ($out_fh, $out_file) = tempfile(UNLINK => 1);
+    my ($err_fh, $err_file) = tempfile(UNLINK => 1);
+    close $out_fh;
+    close $err_fh;
+    push @output_files, $out_file;
+    push @error_files, $err_file;
+}
+
+## Fork threads - each adds different tables in parallel
+for my $thread_num (1..$NUM_THREADS) {
+    my $pid = fork();
+
+    if (!defined $pid) {
+        die "Failed to fork: $!";
+    }
+
+    if ($pid == 0) {
+        ## Child process
+        my $out_file = $output_files[$thread_num-1];
+        my $err_file = $error_files[$thread_num-1];
+        open STDOUT, '>', $out_file or die "Can't redirect STDOUT: $!";
+        open STDERR, '>', $err_file or die "Can't redirect STDERR: $!";
+
+        ## Wait at the barrier
+        my $ready = 0;
+        while (!$ready) {
+            open my $bfh, '+<', $barrier_file or die "Cannot open barrier: $!";
+            flock($bfh, 2);
+            my $count = <$bfh> || 0;
+            chomp $count;
+            $count++;
+            seek($bfh, 0, 0);
+            truncate($bfh, 0);
+            print $bfh "$count\n";
+            $ready = 1 if $count >= $NUM_THREADS;
+            close $bfh;
+            sleep 0.001 unless $ready;
+        }
+
+        ## Each thread adds its assigned tables
+        my $start_table = ($thread_num - 1) * $TABLES_PER_THREAD + 1;
+        my $end_table = $thread_num * $TABLES_PER_THREAD;
+
+        my $success_count = 0;
+        my $failure_count = 0;
+
+        for my $i ($start_table..$end_table) {
+            my $table_name = "race_table_$i";
+
+            ## Add table to the relgroup
+            my $output = $bct->ctl("bucardo add table $table_name relgroup=race_herd db=A");
+
+            if ($output =~ /Added the following tables/ || $output =~ /already in the relgroup/) {
+                print STDOUT "PASS $i\n";
+                $success_count++;
+            } else {
+                print STDOUT "FAIL $i\n";
+                print STDERR "Table $table_name failed: $output\n";
+                $failure_count++;
+            }
+            STDOUT->flush();
+        }
+
+        exit($failure_count);
+    }
+
+    ## Parent: track child PID
+    push @children, $pid;
+}
+
+## Track which tables were successfully added (based on child process output)
+my %table_results;
+my $first_failure = 0;
+
+## Wait for all children to complete and collect all their results first
+for my $i (0..$#children) {
+    my $pid = $children[$i];
+    waitpid($pid, 0);
+    my $exit_code = $? >> 8;
+    push @all_exit_codes, $exit_code;
+
+    ## Read all results from this child
+    open my $out_fh, '<', $output_files[$i];
+    while (my $line = <$out_fh>) {
+        if ($line =~ /^(PASS|FAIL) (\d+)/) {
+            $table_results{$2} = $1;
+        }
+    }
+    close $out_fh;
+
+    open my $err_fh, '<', $error_files[$i];
+    $child_errors{$i+1} = do { local $/; <$err_fh> };
+    close $err_fh;
+}
+
+## Now output test results in order, one at a time
+## Add small delay between results to show progress
+TESTLOOP: for my $table_num (1..$NUM_TABLES) {
+    $t = "Table race_table_$table_num was added to the herd";
+
+    my $result = $table_results{$table_num} || 'FAIL';
+
+    if ($result eq 'PASS') {
+        pass($t);
+        ## Small delay to make progress visible
+        select(undef, undef, undef, 0.05);
+    } else {
+        fail($t);
+
+        ## First failure - show diagnostics and skip remaining
+        if (!$first_failure) {
+            $first_failure = $table_num;
+
+            ## Check database state
+            $dbhX = $bct->connect_database('A', 'bucardo');
+            my $sth = $dbhX->prepare(q{
+                SELECT COUNT(*) FROM bucardo.herdmap
+                WHERE herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
+            });
+            $sth->execute();
+            my ($actual_count) = $sth->fetchrow_array();
+
+            diag("");
+            diag("=== RACE CONDITION DETECTED ===");
+            diag("First failure at table race_table_$table_num");
+            diag("Expected $NUM_TABLES tables in herdmap, but found $actual_count");
+            diag("Missing: " . ($NUM_TABLES - $actual_count) . " tables");
+
+            ## Skip remaining tests
+            my $remaining = $NUM_TABLES - $table_num;
+            SKIP: {
+                skip("Skipping remaining tests due to race condition failure", $remaining);
+            }
+
+            last TESTLOOP;
+        }
+    }
+}
+
+## Skip the final verification since we already handled it
+goto CLEANUP;
+
+CLEANUP:
+
+## Reconnect to check final state (only if no failures were detected)
+if (!$first_failure) {
+    $dbhX = $bct->connect_database('A', 'bucardo');
+
+    ## Get list of tables that were actually added to the herdmap
+    my $sth2 = $dbhX->prepare(q{
+        SELECT g.schemaname || '.' || g.tablename as tablename
+        FROM bucardo.herdmap hm
+        JOIN bucardo.goat g ON (hm.goat = g.id)
+        WHERE hm.herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
+        ORDER BY g.tablename
+    });
+    $sth2->execute();
+    my $added_tables_final = $sth2->fetchall_hashref('tablename');
+
+    ## Check for duplicate entries in herdmap
+    $sth2 = $dbhX->prepare(q{
+        SELECT g.schemaname || '.' || g.tablename as tablename, COUNT(*) as cnt
+        FROM bucardo.herdmap hm
+        JOIN bucardo.goat g ON (hm.goat = g.id)
+        WHERE hm.herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
+        GROUP BY g.schemaname, g.tablename
+        HAVING COUNT(*) > 1
+    });
+    $sth2->execute();
+    my $duplicates_final = $sth2->fetchall_arrayref();
+
+
+    my $tables_added_count = scalar(keys %$added_tables_final);
+
+    if ($tables_added_count != $NUM_TABLES) {
+        diag("");
+        diag("=== RACE CONDITION DETECTED (Final Verification) ===");
+        diag("Expected $NUM_TABLES tables in herdmap, but found $tables_added_count");
+        diag("Missing: " . ($NUM_TABLES - $tables_added_count) . " tables");
+
+        if (@$duplicates_final) {
+            diag("Duplicate entries found: " . scalar(@$duplicates_final));
+            for my $dup (@$duplicates_final) {
+                diag("  " . $dup->[0] . " appears " . $dup->[1] . " times");
+            }
+        }
+    }
+}
+
+END {
+    $bct->stop_bucardo($dbhX) if $dbhX;
+    $dbhX->disconnect() if $dbhX;
+    $dbhA->disconnect() if $dbhA;
+    $dbhB->disconnect() if $dbhB;
+}

--- a/t/02-bctl-table-race.t
+++ b/t/02-bctl-table-race.t
@@ -45,6 +45,7 @@ $location = 'setup';
 ## Configuration
 my $NUM_TABLES = 100;      ## Total tables to create and add
 my $NUM_THREADS = 10;      ## Parallel threads
+my $NUM_SYNCS = 3;         ## Number of syncs to create
 my $TABLES_PER_THREAD = int($NUM_TABLES / $NUM_THREADS);
 
 plan tests => $NUM_TABLES;
@@ -70,8 +71,14 @@ for my $i (1..$NUM_TABLES) {
 }
 $dbhA->commit();
 
-## Create a sync with a herd
-$bct->ctl("bucardo add sync race_sync relgroup=race_herd dbs=A:source,B:target");
+## Create multiple syncs, each with its own herd
+my @sync_names;
+for my $sync_num (1..$NUM_SYNCS) {
+    my $sync_name = "race_sync_$sync_num";
+    my $herd_name = "race_herd_$sync_num";
+    push @sync_names, $sync_name;
+    $bct->ctl("bucardo add sync $sync_name relgroup=$herd_name dbs=A:source,B:target");
+}
 
 ## Ensure test output is not buffered
 $| = 1;
@@ -102,7 +109,7 @@ for (1..$NUM_THREADS) {
 my ($done_fh, $done_file) = tempfile(UNLINK => 1);
 close $done_fh;
 
-## Fork a validation thread that runs "bucardo validate race_sync" every 5 seconds
+## Fork a validation thread that validates all syncs every 5 seconds
 my $validator_pid = fork();
 if (!defined $validator_pid) {
     die "Failed to fork validator: $!";
@@ -125,10 +132,12 @@ if ($validator_pid == 0) {
         close $dfh;
         last if $done =~ /complete/;
 
-        ## Run validate
-        my $output = $bct->ctl("bucardo validate race_sync");
-        print STDOUT "Validate: $output\n";
-        STDOUT->flush();
+        ## Run validate on all syncs
+        for my $sync_name (@sync_names) {
+            my $output = $bct->ctl("bucardo validate $sync_name");
+            print STDOUT "Validate $sync_name: $output\n";
+            STDOUT->flush();
+        }
 
         sleep 5;
     }
@@ -167,7 +176,7 @@ for my $thread_num (1..$NUM_THREADS) {
             sleep 0.001 unless $ready;
         }
 
-        ## Each thread adds its assigned tables
+        ## Each thread adds its assigned tables to different syncs in round-robin fashion
         my $start_table = ($thread_num - 1) * $TABLES_PER_THREAD + 1;
         my $end_table = $thread_num * $TABLES_PER_THREAD;
 
@@ -177,8 +186,12 @@ for my $thread_num (1..$NUM_THREADS) {
         for my $i ($start_table..$end_table) {
             my $table_name = "race_table_$i";
 
+            ## Pick which sync/herd to add this table to (round-robin)
+            my $sync_index = ($i - 1) % $NUM_SYNCS;
+            my $herd_name = "race_herd_" . ($sync_index + 1);
+
             ## Add table to the relgroup
-            my $output = $bct->ctl("bucardo add table $table_name relgroup=race_herd db=A");
+            my $output = $bct->ctl("bucardo add table $table_name relgroup=$herd_name db=A");
 
             if ($output =~ /Added the following tables/ || $output =~ /already in the relgroup/) {
                 print STDOUT "PASS $i\n";
@@ -249,20 +262,28 @@ TESTLOOP: for my $table_num (1..$NUM_TABLES) {
         if (!$first_failure) {
             $first_failure = $table_num;
 
-            ## Check database state
+            ## Check database state for all herds
             $dbhX = $bct->connect_database('A', 'bucardo');
-            my $sth = $dbhX->prepare(q{
-                SELECT COUNT(*) FROM bucardo.herdmap
-                WHERE herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
-            });
-            $sth->execute();
-            my ($actual_count) = $sth->fetchrow_array();
+            my $total_actual_count = 0;
 
             diag("");
             diag("=== RACE CONDITION DETECTED ===");
             diag("First failure at table race_table_$table_num");
-            diag("Expected $NUM_TABLES tables in herdmap, but found $actual_count");
-            diag("Missing: " . ($NUM_TABLES - $actual_count) . " tables");
+
+            for my $sync_num (1..$NUM_SYNCS) {
+                my $herd_name = "race_herd_$sync_num";
+                my $sth = $dbhX->prepare(q{
+                    SELECT COUNT(*) FROM bucardo.herdmap
+                    WHERE herd = ?
+                });
+                $sth->execute($herd_name);
+                my ($actual_count) = $sth->fetchrow_array();
+                $total_actual_count += $actual_count;
+                diag("Herd $herd_name has $actual_count tables");
+            }
+
+            diag("Expected $NUM_TABLES tables total across all herds, but found $total_actual_count");
+            diag("Missing: " . ($NUM_TABLES - $total_actual_count) . " tables");
 
             ## Show error outputs from children
             for my $thread_num (sort keys %child_errors) {
@@ -274,59 +295,64 @@ TESTLOOP: for my $table_num (1..$NUM_TABLES) {
 
             ## Skip remaining tests
             my $remaining = $NUM_TABLES - $table_num;
-            SKIP: {
-                skip("Skipping remaining tests due to race condition failure", $remaining);
-            }
+            skip("Skipping remaining tests due to race condition failure", $remaining);
 
             last TESTLOOP;
         }
     }
 }
 
-## Skip the final verification since we already handled it
-goto CLEANUP;
-
-CLEANUP:
-
 ## Reconnect to check final state (only if no failures were detected)
 if (!$first_failure) {
     $dbhX = $bct->connect_database('A', 'bucardo');
 
-    ## Get list of tables that were actually added to the herdmap
-    my $sth2 = $dbhX->prepare(q{
-        SELECT g.schemaname || '.' || g.tablename as tablename
-        FROM bucardo.herdmap hm
-        JOIN bucardo.goat g ON (hm.goat = g.id)
-        WHERE hm.herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
-        ORDER BY g.tablename
-    });
-    $sth2->execute();
-    my $added_tables_final = $sth2->fetchall_hashref('tablename');
+    my $total_tables_added = 0;
+    my @all_duplicates;
 
-    ## Check for duplicate entries in herdmap
-    $sth2 = $dbhX->prepare(q{
-        SELECT g.schemaname || '.' || g.tablename as tablename, COUNT(*) as cnt
-        FROM bucardo.herdmap hm
-        JOIN bucardo.goat g ON (hm.goat = g.id)
-        WHERE hm.herd = (SELECT name FROM bucardo.herd WHERE name='race_herd')
-        GROUP BY g.schemaname, g.tablename
-        HAVING COUNT(*) > 1
-    });
-    $sth2->execute();
-    my $duplicates_final = $sth2->fetchall_arrayref();
+    ## Check each herd
+    for my $sync_num (1..$NUM_SYNCS) {
+        my $herd_name = "race_herd_$sync_num";
 
+        ## Get list of tables that were actually added to this herdmap
+        my $sth2 = $dbhX->prepare(q{
+            SELECT g.schemaname || '.' || g.tablename as tablename
+            FROM bucardo.herdmap hm
+            JOIN bucardo.goat g ON (hm.goat = g.id)
+            WHERE hm.herd = ?
+            ORDER BY g.tablename
+        });
+        $sth2->execute($herd_name);
+        my $added_tables_final = $sth2->fetchall_hashref('tablename');
 
-    my $tables_added_count = scalar(keys %$added_tables_final);
+        ## Check for duplicate entries in this herdmap
+        $sth2 = $dbhX->prepare(q{
+            SELECT g.schemaname || '.' || g.tablename as tablename, COUNT(*) as cnt
+            FROM bucardo.herdmap hm
+            JOIN bucardo.goat g ON (hm.goat = g.id)
+            WHERE hm.herd = ?
+            GROUP BY g.schemaname, g.tablename
+            HAVING COUNT(*) > 1
+        });
+        $sth2->execute($herd_name);
+        my $duplicates_final = $sth2->fetchall_arrayref();
 
-    if ($tables_added_count != $NUM_TABLES) {
-        diag("");
-        diag("=== RACE CONDITION DETECTED (Final Verification) ===");
-        diag("Expected $NUM_TABLES tables in herdmap, but found $tables_added_count");
-        diag("Missing: " . ($NUM_TABLES - $tables_added_count) . " tables");
+        my $tables_in_herd = scalar(keys %$added_tables_final);
+        $total_tables_added += $tables_in_herd;
 
         if (@$duplicates_final) {
-            diag("Duplicate entries found: " . scalar(@$duplicates_final));
-            for my $dup (@$duplicates_final) {
+            push @all_duplicates, @$duplicates_final;
+        }
+    }
+
+    if ($total_tables_added != $NUM_TABLES) {
+        diag("");
+        diag("=== RACE CONDITION DETECTED (Final Verification) ===");
+        diag("Expected $NUM_TABLES tables total across all herds, but found $total_tables_added");
+        diag("Missing: " . ($NUM_TABLES - $total_tables_added) . " tables");
+
+        if (@all_duplicates) {
+            diag("Duplicate entries found: " . scalar(@all_duplicates));
+            for my $dup (@all_duplicates) {
                 diag("  " . $dup->[0] . " appears " . $dup->[1] . " times");
             }
         }

--- a/t/02-bctl-table-race.t
+++ b/t/02-bctl-table-race.t
@@ -7,15 +7,24 @@
 ## can fail or produce inconsistent results when multiple processes add different tables
 ## to the same relgroup/herd simultaneously.
 ##
-## Expected behavior with 5.6.0 (and presumably earlier): TEST FAILS
-## - Some tables will not be added to the herdmap 
+## The race condition occurs because:
+## 1. Each bucardo process loads the global $GOAT and $HERD hashes at startup
+## 2. Multiple processes check if a table is already in the herd (line 3669 in bucardo)
+## 3. The check uses the in-memory hash, not the current database state
+## 4. If two processes are adding different tables concurrently, both checks pass
+## 5. Both processes insert their tables and call load_bucardo_info() before committing
+## 6. The reload sees an incomplete state, causing hash corruption
+## 7. Some tables fail to be added properly, resulting in missing entries
+##
+## Expected behavior with current code: TEST FAILS
+## - Some tables will not be added to the herdmap (typically 50-70 missing out of 500)
 ## - Errors about uninitialized values in the $GOAT hash
 ## - Exit codes are 0 but actual count doesn't match expected
 ##
 ## Expected behavior after fix: TEST PASSES
-## - All tables should be successfully added to the herdmap
+## - All 500 tables should be successfully added to the herdmap
 ## - No errors about uninitialized values
-## - Actual count matches expected count
+## - Actual count matches expected count (500)
 
 use 5.008003;
 use strict;
@@ -87,6 +96,44 @@ for (1..$NUM_THREADS) {
     close $err_fh;
     push @output_files, $out_file;
     push @error_files, $err_file;
+}
+
+## Create a completion flag file to signal when table-adding threads are done
+my ($done_fh, $done_file) = tempfile(UNLINK => 1);
+close $done_fh;
+
+## Fork a validation thread that runs "bucardo validate race_sync" every 5 seconds
+my $validator_pid = fork();
+if (!defined $validator_pid) {
+    die "Failed to fork validator: $!";
+}
+if ($validator_pid == 0) {
+    ## Validator child process
+    my ($val_out_fh, $val_out_file) = tempfile(UNLINK => 1);
+    my ($val_err_fh, $val_err_file) = tempfile(UNLINK => 1);
+    open STDOUT, '>', $val_out_file or die "Can't redirect STDOUT: $!";
+    open STDERR, '>', $val_err_file or die "Can't redirect STDERR: $!";
+
+    ## Wait for other threads to start
+    sleep 2;
+
+    ## Keep validating until done file is marked complete
+    while (1) {
+        ## Check if we're done
+        open my $dfh, '<', $done_file or die "Cannot open done file: $!";
+        my $done = <$dfh> || '';
+        close $dfh;
+        last if $done =~ /complete/;
+
+        ## Run validate
+        my $output = $bct->ctl("bucardo validate race_sync");
+        print STDOUT "Validate: $output\n";
+        STDOUT->flush();
+
+        sleep 5;
+    }
+
+    exit(0);
 }
 
 ## Fork threads - each adds different tables in parallel
@@ -176,6 +223,14 @@ for my $i (0..$#children) {
     close $err_fh;
 }
 
+## Signal validator thread to stop
+open my $dfh, '>', $done_file or die "Cannot open done file: $!";
+print $dfh "complete\n";
+close $dfh;
+
+## Wait for validator thread to finish
+waitpid($validator_pid, 0);
+
 ## Now output test results in order, one at a time
 ## Add small delay between results to show progress
 TESTLOOP: for my $table_num (1..$NUM_TABLES) {
@@ -208,6 +263,14 @@ TESTLOOP: for my $table_num (1..$NUM_TABLES) {
             diag("First failure at table race_table_$table_num");
             diag("Expected $NUM_TABLES tables in herdmap, but found $actual_count");
             diag("Missing: " . ($NUM_TABLES - $actual_count) . " tables");
+
+            ## Show error outputs from children
+            for my $thread_num (sort keys %child_errors) {
+                if ($child_errors{$thread_num}) {
+                    diag("Thread $thread_num errors:");
+                    diag($child_errors{$thread_num});
+                }
+            }
 
             ## Skip remaining tests
             my $remaining = $NUM_TABLES - $table_num;

--- a/t/02-bctl-table-race.t
+++ b/t/02-bctl-table-race.t
@@ -9,22 +9,22 @@
 ##
 ## The race condition occurs because:
 ## 1. Each bucardo process loads the global $GOAT and $HERD hashes at startup
-## 2. Multiple processes check if a table is already in the herd (line 3669 in bucardo)
+## 2. Multiple processes check if a table is already in the herd
 ## 3. The check uses the in-memory hash, not the current database state
 ## 4. If two processes are adding different tables concurrently, both checks pass
 ## 5. Both processes insert their tables and call load_bucardo_info() before committing
 ## 6. The reload sees an incomplete state, causing hash corruption
 ## 7. Some tables fail to be added properly, resulting in missing entries
 ##
-## Expected behavior with current code: TEST FAILS
-## - Some tables will not be added to the herdmap (typically 50-70 missing out of 500)
+## Expected behavior with bucardo 5.6.0 (and presumably earlier): TEST FAILS
+## - Some tables will not be added to the herdmap
 ## - Errors about uninitialized values in the $GOAT hash
 ## - Exit codes are 0 but actual count doesn't match expected
 ##
 ## Expected behavior after fix: TEST PASSES
-## - All 500 tables should be successfully added to the herdmap
+## - All tables should be successfully added to the herdmap
 ## - No errors about uninitialized values
-## - Actual count matches expected count (500)
+## - Actual count matches expected count
 
 use 5.008003;
 use strict;


### PR DESCRIPTION
When many bucardo commands are run in parallel, there exists a race condition where some of those commands fail. We started to notice this when we tried to build up syncs for multiple schemas with thread pools - instead of adding 1200 tables sequentially, we would add a few at the same time. The idea was to drastically reduce the amount of setup time we would have preparing our syncs, but the reality we quickly ran into was that bucardo would poop the bed sooner than later and mess up our thread pools.

This pull request does three things. First, it makes sure that the test suite is clean by altering one of the tests to not throw a false error when testing with pg16. Second, it adds a test to bucardo's test suite that reliably reproduces this race condition. Finally, it fixes the race condition and shows that all tests pass.