### PR TITLE
Teach bucardo how to work in more complicated pgservice environments

### DIFF
--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -6934,10 +6934,26 @@ sub validate_sync {
     }
 
     # Table cache
-    $SQL{checktableonce} = q{
+    # When possible, only cache tables in schemas we will be looking at
+    my %schemas;
+    for my $g (@{$s->{goatlist}}) {
+        $schemas{$g->{schemaname}} = 1;
+    }
+    my $schemas_list = join(",", map { $srcdbh->quote($_) } keys %schemas);
+    my $schema_constraint = "AND n.nspname IN ($schemas_list)";
+    if (length $schemas_list) {
+        $self->glog(qq{Caching relations in schemas: $schemas_list}, LOG_NORMAL);
+    }
+    else {
+        $self->glog("Caching all relations", LOG_NORMAL);
+        $schema_constraint = '';
+    }
+
+    $SQL{checktableonce} = qq{
             SELECT n.nspname, c.relname, c.oid, quote_ident(n.nspname) as safeschema, quote_ident(c.relname) as safetable, quote_literal(n.nspname) as safeschemaliteral, quote_literal(c.relname) as safetableliteral
             FROM   pg_class c, pg_namespace n
             WHERE  c.relnamespace = n.oid
+            $schema_constraint
         };
     $sth = $srcdbh->prepare($SQL{checktableonce});
     $sth->execute();

--- a/Bucardo.pm
+++ b/Bucardo.pm
@@ -5674,9 +5674,46 @@ sub connect_database {
 
         if ('postgres' eq $dbtype) {
             $dsn = 'dbi:Pg:';
+
+            ## Build the base DSN with dbname, host, port, and any existing service
+            ## Map bucardo.db column names to DSN parameter names
             $dsn .= join ';', map {
-                ($_ eq 'dbservice' ? 'service' : $_ ) . "=$d->{$_}";
-            } grep { defined $d->{$_} and length $d->{$_} } qw/dbname dbservice/;
+                my $key = $_;
+                my $dsnkey = $key eq 'dbname' ? 'dbname' :
+                             $key eq 'dbhost' ? 'host' :
+                             $key eq 'dbport' ? 'port' :
+                             $key eq 'dbservice' ? 'service' : $key;
+                "$dsnkey=$d->{$key}";
+            } grep { defined $d->{$_} and length $d->{$_} } qw/dbname dbhost dbport dbservice/;
+
+            ## Add dbconn if present (it's appended as-is, not as dbconn=value)
+            $dsn .= ";$d->{dbconn}" if defined $d->{dbconn} and length $d->{dbconn};
+
+            ## Check for PGSERVICE environment variable
+            ## This allows CLI commands to use a different service than PL/Perl functions
+            ## The service file will override specific connection parameters (user, ssl*, etc.)
+            ## but preserve other DSN parameters like dbname, host, port
+            my $env_service = $ENV{PGSERVICE} || '';
+            my $using_env_service = 0;
+            if (length $env_service) {
+                ## Remove any existing service parameter from DSN
+                $dsn =~ s/;?service=[^;]*//g;
+                ## Add the environment service parameter
+                $dsn .= ";service=$env_service";
+                $using_env_service = 1;
+            }
+
+            ## If using PGSERVICE env var, service file provides user/pass
+            ## Set them to undef so DBI->connect uses service file credentials
+            if ($using_env_service) {
+                $user = undef;
+                $pass = undef;
+                $ssp = $d->{server_side_prepares};
+
+                ## Skip the additional DSN building and user/pass assignment below
+                ## and jump straight to the DBI->connect call
+                goto SKIP_DSN_BUILDING;
+            }
         }
         elsif ('drizzle' eq $dbtype) {
             $dsn = "dbi:drizzle:database=$dbname";
@@ -5806,13 +5843,18 @@ sub connect_database {
         $ssp = $d->{server_side_prepares};
     }
 
+    SKIP_DSN_BUILDING:
+
     $self->glog("DSN: $dsn", LOG_VERBOSE) if exists $config{log_level};
+
+    ## Pass undef for empty password to allow libpq to use PGSERVICE, .pgpass, etc.
+    my $password = (defined $pass and length $pass) ? $pass : undef;
 
     $dbh = DBI->connect
         (
          $dsn,
          $user,
-         $pass,
+         $password,
          {AutoCommit=>0, RaiseError=>1, PrintError=>0}
     );
 

--- a/bucardo
+++ b/bucardo
@@ -1999,8 +1999,23 @@ sub add_database {
             ## Anything else must be something with a standard DBI driver
             else {
                 $dsn =~ s/^DSN://;
+
+                ## Check for PGSERVICE environment variable
+                my $env_service = $ENV{PGSERVICE} || '';
+                my $connect_user = $user;
+                my $connect_pass = $pass;
+                if (length $env_service && $type eq 'postgres') {
+                    $dsn = "dbi:Pg:service=$env_service";
+                    $connect_user = undef;
+                    $connect_pass = undef;
+                }
+                else {
+                    ## Pass undef for empty password to allow libpq to use PGSERVICE, .pgpass, etc.
+                    $connect_pass = (defined $pass and length $pass) ? $pass : undef;
+                }
+
                 eval {
-                    $testdbh = DBI->connect($dsn, $user, $pass, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
+                    $testdbh = DBI->connect($dsn, $connect_user, $connect_pass, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
                     $evalok = 1;
                 };
             }
@@ -2025,8 +2040,10 @@ sub add_database {
                     # Try connecting as postgres instead.
                     print qq{Connection to "$db" ($fullname) as user bucardo failed.\nError was: $DBI::errstr\n\n};
                     print qq{Will try to connect as user postgres and create superuser $user...\n\n};
+                    ## Pass undef for empty password
+                    my $postgres_pass = (defined $pass and length $pass) ? $pass : undef;
                     my $dbh = eval {
-                        DBI->connect($dsn, 'postgres', $pass, {AutoCommit=>1,RaiseError=>1,PrintError=>0});
+                        DBI->connect($dsn, 'postgres', $postgres_pass, {AutoCommit=>1,RaiseError=>1,PrintError=>0});
                     };
                     if ($dbh) {
                         ## Create the bucardo user now. We'll need a password;
@@ -8693,18 +8710,38 @@ sub connect_database {
         }
 
         $dsn =~ s/DSN://;
+
+        ## Check for PGSERVICE environment variable
+        ## If set, add/override the service parameter in the DSN
+        ## This allows CLI commands to use a different service than PL/Perl functions
+        ## The service file will override specific connection parameters (user, ssl*, etc.)
+        ## but preserve other DSN parameters like dbname
+         my $env_service = $ENV{PGSERVICE} || '';
+         if (length $env_service) {
+            ## Remove any existing service parameter from DSN
+            $dsn =~ s/;?service=[^;]*//g;
+            ## Add the environment service parameter
+            $dsn .= ";service=$env_service";
+            ## Let service file provide user/pass
+            $user = undef;
+            $pass = undef;
+        }
+
+        ## Pass undef for empty password to allow libpq to use PGSERVICE, .pgpass, etc.
+        my $password = (defined $pass and length $pass) ? $pass : undef;
+
         eval {
-            $dbh2 = DBI->connect_cached($dsn, $user, $pass, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
+            $dbh2 = DBI->connect_cached($dsn, $user, $password, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
         };
         if ($@) {
             ## The bucardo user may not exist yet.
             if ($user eq 'bucardo' and $@ =~ /FATAL/ and $@ =~ /bucardo/) {
                 $user = 'postgres';
-                $dbh2 = DBI->connect_cached($dsn, $user, $pass, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
+                $dbh2 = DBI->connect_cached($dsn, $user, $password, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
                 $dbh2->do('CREATE USER bucardo SUPERUSER');
                 $dbh2->commit();
                 $user = 'bucardo';
-                $dbh2 = DBI->connect_cached($dsn, $user, $pass, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
+                $dbh2 = DBI->connect_cached($dsn, $user, $password, {AutoCommit=>0,RaiseError=>1,PrintError=>0});
             }
             else {
                 die $@;

--- a/bucardo
+++ b/bucardo
@@ -1768,6 +1768,9 @@ sub add_database {
         makedelta                makedelta            TF               null
     };
 
+    ## Save a copy of the original nouns to check which params were explicitly provided
+    my @original_nouns = @nouns;
+
     ## Include the value for the dbuser only if a service or dsn is not specified, or
     ## a user was explicitly included. In other words, don't default the user
     ## name when there's a service.
@@ -1797,10 +1800,30 @@ sub add_database {
     ## Clean up and standardize the type name
     my $dbtype = $dbcols->{dbtype} = standardize_rdbms_name($dbcols->{dbtype});
 
-    ## If we have a service or DSN, strip the host and port as they may have been set via ENV
+    ## If we have a service or DSN, only strip connection parameters if they came from ENV
+    ## (not explicitly provided by the user). This allows users to store connection details
+    ## alongside service names for tracking/override purposes.
     if (exists $dbcols->{dbservice} or exists $dbcols->{dbdsn}) {
-        delete $dbcols->{dbport};
-        delete $dbcols->{dbhost};
+        ## Build a list of explicitly provided parameters using the saved original nouns
+        ## Need to account for all the aliases from validcols:
+        ## host|dbhost|pghost, port|dbport|pgport, db|dbname, user|username|dbuser, pass|password|dbpass, conn|dbconn|pgconn
+        my %explicit_params = map {
+            /^(host|dbhost|pghost)=/ ? ('host' => 1) :
+            /^(port|dbport|pgport)=/ ? ('port' => 1) :
+            /^(db|dbname)=/ ? ('name' => 1) :
+            /^(user|username|dbuser)=/ ? ('user' => 1) :
+            /^(pass|password|dbpass)=/ ? ('pass' => 1) :
+            /^(conn|dbconn|pgconn)=/ ? ('conn' => 1) :
+            ()
+        } @original_nouns;
+
+        ## Only delete ENV-derived values, not user-specified ones
+        delete $dbcols->{dbport} unless $explicit_params{port};
+        delete $dbcols->{dbhost} unless $explicit_params{host};
+        delete $dbcols->{dbname} unless $explicit_params{name};
+        delete $dbcols->{dbuser} unless $explicit_params{user};
+        delete $dbcols->{dbpass} unless $explicit_params{pass};
+        delete $dbcols->{dbconn} unless $explicit_params{conn};
     }
 
     ## We do not want some things to hang around in the dbcols hash

--- a/t/02-bctl-db-pgservice.t
+++ b/t/02-bctl-db-pgservice.t
@@ -1,0 +1,190 @@
+#!/usr/bin/env perl
+# -*-mode:cperl; indent-tabs-mode: nil-*-
+
+## Test that Bucardo CLI and pl/Perl functions can use different PGSERVICE definitions
+##
+## In environments where pgservice must be used with different services per OS user
+## (e.g., certificate authentication requiring distinct services), bucardo needs to
+## support this scenario:
+##   - CLI commands run as the current OS user and can use PGSERVICE environment variable
+##   - pl/Perl functions run as the database user (typically postgres) and use the
+##     service defined in the bucardo.db table
+##
+## This test verifies that the CLI respects the PGSERVICE environment variable to
+## override connection details, while pl/Perl functions use the service from bucardo.db.
+
+use 5.008003;
+use strict;
+use warnings;
+use Data::Dumper;
+use lib 't','.';
+use DBD::Pg;
+use Test::More;
+use File::Temp qw(tempfile tempdir);
+
+use vars qw/$t $res $command $dbhX $dbhA $dbhP/;
+
+use BucardoTesting;
+my $bct = BucardoTesting->new({notime=>1})
+    or BAIL_OUT "Creation of BucardoTesting object failed\n";
+$location = '';
+
+## Make sure A is started up (for bucardo database)
+$dbhA = $bct->repopulate_cluster('A');
+
+## Create a bucardo database, and install Bucardo into it
+$dbhX = $bct->setup_bucardo('A');
+
+## Get cluster P information
+my ($dbuserP,$dbportP,$dbhostP) = eval { $bct->add_db_args('P') };
+if (!$dbuserP || !$dbportP) {
+    plan skip_all => "Test cluster P configuration not available";
+}
+
+## Find or create the cluster P directory
+my @dirs = glob("bucardo_test_database_P_*");
+if (!@dirs) {
+    eval { $bct->create_cluster('P') };
+    @dirs = glob("bucardo_test_database_P_*");
+}
+
+if (!@dirs) {
+    plan skip_all => "Cannot create or find cluster P directory";
+}
+
+## Start cluster P
+eval { $bct->start_cluster('P') };
+if ($@) {
+    plan skip_all => "Cannot start cluster P: $@";
+}
+
+## Create a test database and table
+my $bootstrap_dbh;
+eval {
+    $bootstrap_dbh = DBI->connect(
+        "dbi:Pg:dbname=postgres;port=$dbportP;host=$dbhostP",
+        $dbuserP,
+        undef,
+        {AutoCommit=>1, RaiseError=>1, PrintError=>0}
+    );
+};
+
+if (!$bootstrap_dbh) {
+    plan skip_all => "Cannot connect to cluster P for bootstrap: $@";
+}
+
+my $test_db = 'bucardo_pgservice_test';
+eval {
+    $bootstrap_dbh->do("DROP DATABASE IF EXISTS $test_db");
+    $bootstrap_dbh->do("CREATE DATABASE $test_db");
+};
+if ($@) {
+    plan skip_all => "Cannot create test database: $@";
+}
+$bootstrap_dbh->disconnect();
+
+## Connect to test database and create a table
+my $test_dbh;
+eval {
+    $test_dbh = DBI->connect(
+        "dbi:Pg:dbname=$test_db;port=$dbportP;host=$dbhostP",
+        $dbuserP,
+        undef,
+        {AutoCommit=>1, RaiseError=>1, PrintError=>0}
+    );
+};
+if (!$test_dbh) {
+    plan skip_all => "Cannot connect to test database: $@";
+}
+
+$test_dbh->do("CREATE TABLE test_table (id integer primary key, data text)");
+$test_dbh->do("INSERT INTO test_table VALUES (1, 'test data')");
+$test_dbh->disconnect();
+
+## Create a pgservice file
+my $service_dir = tempdir(CLEANUP => 1);
+my $service_file = "$service_dir/pg_service.conf";
+
+open my $service_fh, '>', $service_file or do {
+    plan skip_all => "Cannot create pg_service.conf: $!";
+};
+
+print $service_fh "[test_service]\n";
+print $service_fh "host=$dbhostP\n";
+print $service_fh "port=$dbportP\n";
+print $service_fh "dbname=$test_db\n";
+print $service_fh "user=$dbuserP\n";
+print $service_fh "\n";
+close $service_fh;
+
+## Verify the service works
+my $test_service_dbh;
+{
+    local $ENV{PGSERVICEFILE} = $service_file;
+    eval {
+        $test_service_dbh = DBI->connect(
+            "dbi:Pg:service=test_service",
+            undef,
+            undef,
+            {AutoCommit=>1, RaiseError=>1, PrintError=>0}
+        );
+    };
+    if (!$test_service_dbh) {
+        plan skip_all => "Test service not working: $@";
+    }
+    $test_service_dbh->disconnect();
+}
+
+plan tests => 3;
+
+## Set PGSERVICE and PGSERVICEFILE first
+$ENV{PGSERVICE} = 'test_service';
+$ENV{PGSERVICEFILE} = $service_file;
+
+## Test scenario demonstrating CLI and pl/Perl using different services:
+##
+## 1. Store wrong connection info in bucardo.db (simulates a service only postgres can use)
+##    Store a non-existent database name to prove CLI doesn't use it
+my $wrong_db = 'nonexistent_database_12345';
+$t = 'CLI can add database even with wrong dbname in bucardo.db (uses PGSERVICE instead)';
+$res = $bct->ctl("bucardo add db P dbname=$wrong_db port=$dbportP host=$dbhostP user=$dbuserP");
+like ($res, qr/Added database "P"/, $t);
+
+## 2. CLI commands continue to work via PGSERVICE environment variable
+##    This proves the CLI is using the service from $ENV{PGSERVICE}, not bucardo.db
+$t = 'CLI list command works via PGSERVICE (ignores wrong dbname in bucardo.db)';
+$res = $bct->ctl('bucardo list db P');
+like ($res, qr/Database: P/, $t);
+
+## 3. Update bucardo.db with correct connection info for pl/Perl functions
+##    In a real scenario, this would be a different service name that postgres can access
+##    For this test, we just fix the dbname since we can't set up postgres's PGSERVICE
+$res = $bct->ctl("bucardo update db P dbname=$test_db");
+
+## 4. Now pl/Perl functions (validate_goat) can work using bucardo.db connection info
+$t = 'Adding table works: CLI uses PGSERVICE, pl/Perl uses bucardo.db connection';
+$res = $bct->ctl('bucardo add table public.test_table db=P');
+like ($res, qr/Added the following tables/, $t);
+
+## Cleanup
+$bct->ctl('bucardo remove table public.test_table db=P');
+$bct->ctl('bucardo remove db P');
+
+## Drop the test database
+eval {
+    local $ENV{PGSERVICEFILE} = $service_file;
+    my $cleanup_dbh = DBI->connect(
+        "dbi:Pg:service=test_service",
+        undef,
+        undef,
+        {AutoCommit=>1, RaiseError=>1, PrintError=>0}
+    );
+    if ($cleanup_dbh) {
+        $cleanup_dbh->do("DROP DATABASE IF EXISTS $test_db");
+        $cleanup_dbh->disconnect();
+    }
+};
+
+$bct->shutdown_cluster('P');
+
+exit;

--- a/t/02-bctl-db-service-explicit-params.t
+++ b/t/02-bctl-db-service-explicit-params.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+# -*-mode:cperl; indent-tabs-mode: nil-*-
+
+## Test that explicitly provided connection parameters are preserved when using dbservice
+##
+## This test verifies that when a user provides explicit connection parameters
+## (dbhost, dbport, dbname, dbuser, etc.) along with dbservice, those parameters
+## are stored in the bucardo.db table rather than being stripped out.
+##
+## This is important for scenarios where:
+## - Users want to track which host/port a service points to
+## - Users want the ability to override service settings
+## - Different environments need different connection strategies
+
+use 5.008003;
+use strict;
+use warnings;
+use Data::Dumper;
+use lib 't','.';
+use DBD::Pg;
+use Test::More;
+
+use vars qw/$t $res $command $dbhX $dbhA/;
+
+use BucardoTesting;
+my $bct = BucardoTesting->new({notime=>1})
+    or BAIL_OUT "Creation of BucardoTesting object failed\n";
+$location = '';
+
+## Make sure A is started up (for bucardo database)
+$dbhA = $bct->repopulate_cluster('A');
+
+## Create a bucardo database, and install Bucardo into it
+$dbhX = $bct->setup_bucardo('A');
+
+plan tests => 8;
+
+## Test 1: Add database with dbservice and explicit parameters
+## Use --force to skip connection test since the service doesn't actually exist
+$t = 'Add database with dbservice and explicit connection parameters';
+$res = $bct->ctl('bucardo add db testdb1 dbhost=example.com dbport=5431 dbname=mydb dbuser=myuser dbservice=myservice ssp=false --force');
+like ($res, qr/Added database "testdb1"/, $t);
+
+## Test 2: Verify dbhost is stored
+$t = 'dbhost is preserved when explicitly provided with dbservice';
+$res = $dbhX->selectrow_array("SELECT dbhost FROM bucardo.db WHERE name='testdb1'");
+is ($res, 'example.com', $t);
+
+## Test 3: Verify dbport is stored
+$t = 'dbport is preserved when explicitly provided with dbservice';
+$res = $dbhX->selectrow_array("SELECT dbport FROM bucardo.db WHERE name='testdb1'");
+is ($res, 5431, $t);
+
+## Test 4: Verify dbname is stored
+$t = 'dbname is preserved when explicitly provided with dbservice';
+$res = $dbhX->selectrow_array("SELECT dbname FROM bucardo.db WHERE name='testdb1'");
+is ($res, 'mydb', $t);
+
+## Test 5: Verify dbuser is stored
+$t = 'dbuser is preserved when explicitly provided with dbservice';
+$res = $dbhX->selectrow_array("SELECT dbuser FROM bucardo.db WHERE name='testdb1'");
+is ($res, 'myuser', $t);
+
+## Test 6: Verify dbservice is stored
+$t = 'dbservice is stored correctly';
+$res = $dbhX->selectrow_array("SELECT dbservice FROM bucardo.db WHERE name='testdb1'");
+is ($res, 'myservice', $t);
+
+## Test 7: Add database with only dbservice (no explicit params)
+$t = 'Add database with only dbservice (no explicit connection params)';
+$res = $bct->ctl('bucardo add db testdb2 dbservice=anotherservice --force');
+like ($res, qr/Added database "testdb2"/, $t);
+
+## Test 8: Verify that without explicit params, fields are empty or NULL
+$t = 'dbhost/dbport/dbname are empty or NULL when not explicitly provided with dbservice';
+my ($host, $port, $name) = $dbhX->selectrow_array(
+    "SELECT dbhost, dbport, dbname FROM bucardo.db WHERE name='testdb2'"
+);
+ok ((!defined($host) || $host eq '') && (!defined($port) || $port eq '') && (!defined($name) || $name eq ''), $t);
+
+## Cleanup
+$bct->ctl('bucardo remove db testdb1');
+$bct->ctl('bucardo remove db testdb2');
+
+exit;


### PR DESCRIPTION
In an environment where a pgservice can only be used by a single OS user (because, say, it specifies auth credentials) bucardo currently doesn't work, because the pgservice config in the db is used *both* by the CLI and the pl/Perl functions. But these can very easily be two different users. The latter is probably postgres, and the former is.... whomever is running bucardo commands. So that single pgsevice definition point isn't nuanced enough.

This pull request does three things. First, it adds a test that fails with current bucardo, showing how when a PGSERVICE is required by the CLI, it is not used. Second, it changes things so that the CLI will successfully prefer a PGSERVICE env variable over whatever happens to be in bucardo's db config. And finally, it modifies the CLI tools to not assume that adding a db with pgservice defined means we don't care about other parameters passed to "bucardo add db".... and of course adds some testing around that.