### PR TITLE
Fix regex to allow hyphens in schema/table names for remove command

### DIFF
--- a/bucardo
+++ b/bucardo
@@ -3752,7 +3752,7 @@ sub remove_relation {
 
         ## Bucardo won't fully support a table name that starts with "db=". Darn.
         for my $name (grep { ! /^db=/ } @nouns) {
-            if ($name =~ /^\w[\w\d]*\.\w[\w\d]*$/) {
+            if ($name =~ /^[\w][\w\d\-]*\.[\w][\w\d\-]*$/) {
                 if (! exists $GOAT->{by_fullname}{$name}) {
                     print qq{No such $reltype: $name\n};
                     next;


### PR DESCRIPTION
## Summary

- Fixes the `remove table` command failing with "Please use the full schema.table name" when schema or table names contain hyphens (e.g., `fraud-feature-manager-obsolete.schema_migrations`)
- The validation regex on line 3755 only allowed `\w` (word characters: `[a-zA-Z0-9_]`), rejecting valid PostgreSQL identifiers with hyphens
- Updated regex to `^[\w][\w\d\-]*\.[\w][\w\d\-]*$` to permit hyphens

## Reproduction

```bash
bucardo remove table fraud-feature-manager-obsolete.schema_migrations
# Error: Please use the full schema.table name
```

## Fix

```perl
# Before
if ($name =~ /^\w[\w\d]*\.\w[\w\d]*$/) {

# After
if ($name =~ /^[\w][\w\d\-]*\.[\w][\w\d\-]*$/) {
```
## Test
<img width="1024" height="309" alt="image" src="https://github.com/user-attachments/assets/8344dfd4-d2b4-45d2-b597-3d24c3176027" />
